### PR TITLE
Updates repeatable quests values and copy

### DIFF
--- a/docs/Repeatable_Quests.md
+++ b/docs/Repeatable_Quests.md
@@ -1,23 +1,25 @@
 # Repeatable EXP Quests
-The uaRO server offers a variety of **repeatable quests** where players are tasked to collect a specific number of items, typically **20**, **25**, or **50**.
+Repeatable EXP quests are a reliable way to level up while also collecting useful loot. They come in two forms: **item gathering**, where you turn in monster drops, and **monster hunting**, where you defeat a set number of enemies. Both give Base and Job EXP and can be repeated as often as you like, making them a steady option when regular grinding slows down.  
 
-Upon completing these quests, players receive **EXP rewards**. These items are highly valuable as they can be:
-- **Traded** or **sold** between players
-- **Saved** for future use on other characters
-
-!!! note
-    If a player receives both a **Monster Hunting** quest and an **Item Turn-In** quest from the same NPC, they will not be able to complete the Item Turn-In quest until they finish or abandon the Monster Hunting quest.
-    
-Players can gather the required items and turn them in to specific NPCs to claim their rewards. These quests provide an efficient way to gain **EXP** and valuable resources.
+Some NPCs offer both quest types. You can accept both, but if they come from the same NPC you’ll need to finish or abandon the **Monster Hunting** quest before turning in items.  
 
 
 
 ---
 
-
 ## Item Turn-In Quests
 
-| **NPC** | **Location** | **Min Level** | **Max Level** | **Items** | **Base EXP Reward** | **Job EXP Reward** | **Base EXP Per Item** | **Job EXP Per Item** |
+Item gathering quests ask you to collect **20**, **25**, or **50** of a specific item. Turning them in rewards **Base and Job EXP**, making these quests a steady way to level while farming useful drops.  
+
+Collected items also hold value beyond quests:  
+- They can be **traded or sold** to other players  
+- They can be **saved** to boost future characters  
+
+Because you decide where and how to farm, item quests are flexible—use them to earn zeny, prepare turn-ins ahead of time, or gain reliable EXP outside of your usual grinding spots.    
+
+### Item Quest List
+
+| NPC | Location | Min Level | Max Level | Items | Base EXP | Job EXP | Base EXP Per Item | Job EXP Per Item |
 |:---|:---|---:|---:|:---|---:|---:|---:|---:|
 | **Langry** | `/navi gef_fild07 321/193` | 2 | 20 | 25 Fluff | 770 | 60 | 30 | 2 |
 | **Halgus** | `/navi gef_fild04 191/54` | 2 | 20 | 25 Chrysalis | 770 | 60 | 30 | 2 |
@@ -37,30 +39,32 @@ Players can gather the required items and turn them in to specific NPCs to claim
 
 
 ### Item Purchase Locations
-Some items can be bought from NPCs:
+Some turn-in items can be bought directly from NPCs. **Antelope Horns** cannot be purchased with the Discount skill and cannot be vended to other players.  
 
-- **Bill of Birds** can be purchased in Morroc Ruins from NPCs at `/navi moc_ruins 81/113` and `/navi moc_ruins 93/53`.
-- **Acorn** can be bought in Moscovia from the Acorn Dealer (`/navi moscovia 208/182`).
-- **Antelope Horn** can be bought in Niflheim from the Tool Dealer (`/navi niflheim 218/197`). Discount cannot be used on this item.
+- **Bill of Birds** – Morroc Ruins (`/navi moc_ruins 81/113`, `/navi moc_ruins 93/53`)  
+- **Acorn** – Moscovia, Acorn Dealer (`/navi moscovia 208/182`)  
+- **Antelope Horn** – Niflheim, Tool Dealer (`/navi niflheim 218/197`)  
 
 
 
 ---
 
-
 ## Monster Hunting
 
-The following NPCs offer players a choice of how many monsters they want to hunt, with options of **50**, **100**, or **150**. All three options yield the same EXP per kill, with hunting **100 monsters** rewarding twice as much as hunting **50**.
+Hunting quests let you choose to defeat **50**, **100**, or **150** monsters for **Base and Job EXP** rewards. A 50-monster hunt can grant up to **1 Base Level** and **1 Job Level**, while 100 and 150 hunts can grant up to **2** and **3 levels**.  
 
-!!! tip
-    Party members who are within the killer's screen range will share the kill count (the final blow dealer must be visible on screen). If the player accidentally chooses the wrong option, they can abandon the quest and lose all current progress, allowing them to select a different monster hunt size.
+These quests are especially effective in parties, since everyone’s kills count toward the total. As long as the killer is visible on screen, nearby party members will share the kill. If you pick the wrong option, you can abandon the quest to reset and choose a different hunt size.  
 
-For every **50 monsters** killed, players can gain up to **1 Base Level** and **1 Job Level**. For **100** and **150** monster turn-ins, the maximum gains are **2** and **3 levels**, respectively. Please note that **Homunculus** and **Mercenary** kills will not count towards the kill count. Additionally, players can retain the quest, become a **Transcendent**, and claim the reward before reaching the minimum level requirement.
+Unlike item turn-ins, every kill counts, no drops required. Hunting quests are also a good way to explore new maps and face a wider variety of monsters while keeping steady EXP gains.  
 
-!!! note
-    The rewards listed are based on a **50-monster** turn-in. To calculate rewards for hunting **100** or **150** monsters, simply double or triple the values.
+Please note that **Homunculus kills do not count**, but **Mercenary kills do**. You can also hold the quest, become a **Transcendent**, and then claim the reward once you meet the minimum level requirement.  
 
-| NPC | Location | Min Level | Max Level | Monster | Base EXP | Job EXP | Base EXP / Monster | Job EXP / Monster |
+### Hunting Quest List
+Rewards shown are for a **50-monster** turn-in. For **100** or **150**, simply double or triple the values.  
+
+Monsters marked with `*` are on maps that require a quest to access.  
+
+| NPC | Location | Min Level | Max Level | Monster | Base EXP | Job EXP | Base EXP Per Monster | Job EXP Per Monster |
 |:---|:---|---:|---:|:---|---:|---:|---:|---:|
 | **Langry** | `/navi gef_fild07 321/193` | 2 | 20 | Fabre | 770 | 60 | 15 | 1 |
 | **Halgus** | `/navi gef_fild04 191/54` | 2 | 20 | Pupa | 770 | 60 | 15 | 1 |
@@ -71,21 +75,19 @@ For every **50 monsters** killed, players can gain up to **1 Base Level** and **
 | **Private Jeremy** | `/navi moc_fild11 57/138` | 25 | 60 | Golem | 28,000 | 18,000 | 560 | 360 |
 | **Shone** | `/navi moc_fild17 208/346` | 25 | 60 | Hode | 31,550 | 22,500 | 631 | 450 |
 | **Lemly** | `/navi moc_fild17 66/273` | 30 | 65 | Frilldora | 60,000 | 46,000 | 1,200 | 900 |
-| **Li** | `/navi pay_fild10 108/357` | 35 | 70 | Dokebi | 42,000 | 36,000 | 840 | 720 |
-| **Lella** | `/navi ayo_fild01 44/241` | 36 | 65 | Leaf Cat | 25,740 | 31,512 | 515 | 630 |
-| **Cuir** | `/navi cmd_fild01 362/256` | 45 | 80 | Alligator | 172,375 | 108,250 | 3,448 | 2,165 |
-| **Gandolf** | `/navi lhz_dun01 146/287` | 45 | 80 | Remover* | 275,000 | 170,000 | 5,500 | 3,400 |
-| **Local Villager** | `/navi ein_fild01 43/249` | 60 | 74 | Demon Pungus | 250,266 | 144,452 | 5,005 | 2,889 |
-| **Lilla** | `/navi um_fild01 35/281` | 60 | 85 | Dryad | 234,855 | 126,905 | 4,697 | 2,538 |
-| **Shea** | `/navi tur_dun03 125/195` | 60 | 85 | Assaulter* | 425,000 | 275,000 | 8,500 | 5,500 |
-| **Vegetable Farmer** | `/navi ein_fild06 82/171` | 70 | 95 | Goat | 258,489 | 155,155 | 5,170 | 3,103 |
-| **Henry** | `/navi ice_dun03 140/26` | 70 | 95 | Ice Titan* | 910,000 | 650,000 | 18,200 | 13,000 |
-| **Monica** | `/navi geffen 112/63` | 70 | 98 | Succubus* | 1,325,000 | 950,000 | 26,500 | 19,000 |
-| **Miner** | `/navi beach_dun 269/71` | 75 | 97 | Medusa | 515,700 | 352,275 | 10,314 | 7,046 |
-| **Jotun Tribesman** | `/navi mag_dun01 127/71` | 75 | 97 | Lava Golem | 484,800 | 290,700 | 9,696 | 5,814 |
-| **Coal Miner** | `/navi mag_dun02 46/40` | 75 | 97 | Deleter | 387,734 | 232,733 | 7,755 | 4,655 |
-| **Ptero** | `/navi abyss_03 117/31` | 75 | 97 | Gold Acidus* | 1,285,000 | 815,000 | 25,700 | 16,300 |
-| **Kirby** | `/navi nyd_dun01 146/154` | 75 | 98 | Draco* | 925,000 | 700,000 | 18,500 | 14,000 |
-| **Emmerich** | `/navi thor_v03 57/245` | 75 | 98 | Salamander* | 2,150,000 | 1,550,000 | 43,000 | 31,000 |
-
-
+| **Li** | `/navi pay_fild10 108/357` | 35 | 70 | Dokebi | 84,000 | 72,000 | 1,680 | 1,440 |
+| **Lella** | `/navi ayo_fild01 44/241` | 36 | 65 | Leaf Cat | 51,480 | 63,024 | 1,029 | 1,260 |
+| **Cuir** | `/navi cmd_fild01 362/256` | 45 | 80 | Alligator | 137,900 | 86,600 | 6,895 | 4,330 |
+| **Gandolf** | `/navi lhz_dun01 146/287` | 45 | 80 | Remover`*` | 550,000 | 340,000 | 11,000 | 6,800 |
+| **Local Villager** | `/navi ein_fild01 43/249` | 60 | 74 | Demon Pungus | 500,532 | 288,904 | 10,010 | 5,778 |
+| **Lilla** | `/navi um_fild01 35/281` | 60 | 85 | Dryad | 524,970 | 283,670 | 10,499 | 5,673 |
+| **Shea** | `/navi tur_dun03 125/195` | 60 | 85 | Assaulter`*` | 850,000 | 550,000 | 17,000 | 11,000 |
+| **Vegetable Farmer** | `/navi ein_fild06 82/171` | 70 | 85 | Goat | 1,033,956 | 620,620 | 20,680 | 12,413 |
+| **Henry** | `/navi ice_dun03 140/26` | 70 | 95 | Ice Titan`*` | 3,640,000 | 2,600,000 | 72,800 | 52,000 |
+| **Monica** | `/navi geffen 112/63` | 70 | 98 | Succubus`*` | 5,300,000 | 3,800,000 | 106,000 | 76,000 |
+| **Coal Miner** | `/navi mag_dun02 46/40` | 75 | 97 | Deleter | 1,550,936 | 930,932 | 31,019 | 18,619 |
+| **Jotun Tribesman** | `/navi mag_dun01 127/71` | 75 | 97 | Lava Golem | 1,939,200 | 1,162,800| 38,784 | 23,256 |
+| **Miner** | `/navi beach_dun 269/71` | 75 | 97 | Medusa | 2,062,800 | 1,409,100 | 41,256 | 28,182 |
+| **Ptero** | `/navi abyss_03 117/31` | 75 | 97 | Gold Acidus`*` | 2,570,000 | 1,630,000 | 51,400 | 32,600 |
+| **Kirby** | `/navi nyd_dun01 146/154` | 75 | 98 | Draco`*` | 3,700,000 | 2,800,000 | 74,000 | 56,000 |
+| **Emmerich** | `/navi thor_v03 57/245` | 75 | 98 | Salamander`*` | 8,600,000 | 6,200,000 | 172,000 | 124,000 |

--- a/docs/Repeatable_Quests.md
+++ b/docs/Repeatable_Quests.md
@@ -1,5 +1,5 @@
 # Repeatable EXP Quests
-The *uaRO* server offers a variety of **repeatable quests** where players are tasked to collect a specific number of items, typically **20**, **25**, or **50**.
+The uaRO server offers a variety of **repeatable quests** where players are tasked to collect a specific number of items, typically **20**, **25**, or **50**.
 
 Upon completing these quests, players receive **EXP rewards**. These items are highly valuable as they can be:
 - **Traded** or **sold** between players
@@ -14,40 +14,39 @@ Players can gather the required items and turn them in to specific NPCs to claim
 
 ---
 
+
 ## Item Turn-In Quests
 
-| **NPC**               | **Location**               | **Min Level** | **Max Level** | **Items**                 | **Base EXP Reward** | **Job EXP Reward** | **Base EXP Per Item** | **Job EXP Per Item** |
-|:----------------------|:---------------------------|--------------:|--------------:|:--------------------------|--------------------:|-------------------:|----------------------:|---------------------:|
-| **Langry**             | /navi gef_fild07 321/193   |             2 |            20 | 25 Fluff                   |                 770  |                 60 |                    30  |                   2  |
-| **Halgus**             | /navi gef_fild04 191/54    |             2 |            20 | 25 Chrysalis               |                 770  |                 60 |                    30  |                   2  |
-| **Gregor**             | /navi moc_fild02 74/329    |            10 |            30 | 25 Bill of Birds           |               8,000  |              4,000 |                   320  |                 160  |
-| **Laertes**            | /navi prt_fild04 356/148   |            15 |            45 | 25 Powder of Butterfly     |               5,900  |              2,250 |                   236  |                  90  |
-| **Nutters**            | /navi mjolnir_01 293/20    |            18 |            60 | 25 Acorn                   |               7,200  |              7,810 |                   288  |                 312  |
-| **Yullo**              | /navi mjolnir_01 296/29    |            24 |            60 | 25 Porcupine Quill         |              20,850  |             12,544 |                   834  |                 510  |
-| **Private Jeremy**     | /navi moc_fild11 57/138    |            25 |            60 | 25 Stone Heart             |              28,000  |             18,000 |                 1,120  |                 720  |
-| **Shone**              | /navi moc_fild17 208/346   |            25 |            60 | 25 Earthworm Peeling       |              39,438  |             28,120 |                 1,577  |               1,124  |
-| **Lemly**              | /navi moc_fild17 66/273    |            30 |            65 | 25 Frill                   |              60,000  |             46,000 |                 2,400  |               1,840  |
-| **Li**                 | /navi pay_fild10 108/357   |            35 |            70 | 50 Dokebi Horns            |              84,000  |             72,000 |                 1,680  |               1,440  |
-| **Lella**              | /navi ayo_fild01 44/241    |            36 |            65 | 50 Huge Leaf               |              51,480  |             63,024 |                 1,029  |               1,260  |
-| **Cuir**               | /navi cmd_fild01 362/256   |            45 |            80 | 20 Anolian Skin            |             137,900  |             86,600 |                 6,895  |               4,330  |
-| **Local Villager**     | /navi ein_fild01 43/249    |            60 |            74 | 50 Bacillus                |             500,532  |            288,904 |                10,010  |               5,778  |
-| **Lilla**              | /navi um_fild01 35/281     |            60 |            85 | 50 Sharp Leaf              |             524,970  |            283,670 |                10,499  |               5,673  |
-| **Vegetable Farmer**   | /navi ein_fild06 82/171    |            70 |            85 | 50 Antelope Horn           |             516,978  |            310,310 |                10,339  |               6,206  |
+| **NPC** | **Location** | **Min Level** | **Max Level** | **Items** | **Base EXP Reward** | **Job EXP Reward** | **Base EXP Per Item** | **Job EXP Per Item** |
+|:---|:---|---:|---:|:---|---:|---:|---:|---:|
+| **Langry** | `/navi gef_fild07 321/193` | 2 | 20 | 25 Fluff | 770 | 60 | 30 | 2 |
+| **Halgus** | `/navi gef_fild04 191/54` | 2 | 20 | 25 Chrysalis | 770 | 60 | 30 | 2 |
+| **Gregor** | `/navi moc_fild02 74/329` | 10 | 30 | 25 Bill of Birds | 8,000 | 4,000 | 320 | 160 |
+| **Laertes** | `/navi prt_fild04 356/148` | 15 | 45 | 25 Powder of Butterfly | 5,900 | 2,250 | 236 | 90 |
+| **Nutters** | `/navi mjolnir_01 293/20` | 18 | 60 | 25 Acorn | 7,200 | 7,810 | 288 | 312 |
+| **Yullo** | `/navi mjolnir_01 296/29` | 24 | 60 | 25 Porcupine Quill | 20,850 | 12,544 | 834 | 510 |
+| **Private Jeremy** | `/navi moc_fild11 57/138` | 25 | 60 | 25 Stone Heart | 28,000 | 18,000 | 1,120 | 720 |
+| **Shone** | `/navi moc_fild17 208/346` | 25 | 60 | 25 Earthworm Peeling | 39,438 | 28,120 | 1,577 | 1,124 |
+| **Lemly** | `/navi moc_fild17 66/273` | 30 | 65 | 25 Frill | 60,000 | 46,000 | 2,400 | 1,840 |
+| **Li** | `/navi pay_fild10 108/357` | 35 | 70 | 50 Dokebi Horns | 84,000 | 72,000 | 1,680 | 1,440 |
+| **Lella** | `/navi ayo_fild01 44/241` | 36 | 65 | 50 Huge Leaf | 51,480 | 63,024 | 1,029 | 1,260 |
+| **Cuir** | `/navi cmd_fild01 362/256` | 45 | 80 | 20 Anolian Skin | 137,900 | 86,600 | 6,895 | 4,330 |
+| **Local Villager** | `/navi ein_fild01 43/249` | 60 | 74 | 50 Bacillus | 500,532 | 288,904 | 10,010 | 5,778 |
+| **Lilla** | `/navi um_fild01 35/281` | 60 | 85 | 50 Sharp Leaf | 524,970 | 283,670 | 10,499 | 5,673 |
+| **Vegetable Farmer** | `/navi ein_fild06 82/171` | 70 | 85 | 50 Antelope Horn | 516,978 | 310,310 | 10,339 | 6,206 |
 
 
 ### Item Purchase Locations
-
 Some items can be bought from NPCs:
 
-- **Bill of Birds** can be purchased in Morroc from:
-  - /navi moc_ruins 81/113
-  - /navi moc_ruins 93/53
-- **Acorn** can be bought in Moscovia from the Acorn Dealer: /navi moscovia 208/182
-- **Antelope Horn** can be bought in Niflheim from the Tool Dealer: /navi niflheim 218/197
+- **Bill of Birds** can be purchased in Morroc Ruins from NPCs at `/navi moc_ruins 81/113` and `/navi moc_ruins 93/53`.
+- **Acorn** can be bought in Moscovia from the Acorn Dealer (`/navi moscovia 208/182`).
+- **Antelope Horn** can be bought in Niflheim from the Tool Dealer (`/navi niflheim 218/197`). Discount cannot be used on this item.
 
 
 
 ---
+
 
 ## Monster Hunting
 
@@ -61,32 +60,32 @@ For every **50 monsters** killed, players can gain up to **1 Base Level** and **
 !!! note
     The rewards listed are based on a **50-monster** turn-in. To calculate rewards for hunting **100** or **150** monsters, simply double or triple the values.
 
-| **NPC**              | **Location**                 | **Min Level** | **Max Level** | **Monster**       | **Base EXP (50)** | **Job EXP (50)** | **Base EXP Per Monster** | **Job EXP Per Monster** |
-|:---------------------|:-----------------------------|--------------:|--------------:|:------------------|------------------:|-----------------:|-------------------------:|------------------------:|
-| **Langry**           | /navi gef_fild07 321/193      |             2 |            20 | Fabre             |               770  |               60 |                      15  |                      1  |
-| **Halgus**           | /navi gef_fild04 191/54       |             2 |            20 | Pupa              |               770  |               60 |                      15  |                      1  |
-| **Gregor**           | /navi moc_fild02 74/329       |            10 |            30 | Peco Peco         |             8,000  |            4,000 |                     160  |                     80  |
-| **Laertes**          | /navi prt_fild04 356/148      |            15 |            45 | Creamy            |             5,900  |            2,250 |                     118  |                     45  |
-| **Nutters**          | /navi mjolnir_01 293/20       |            18 |            60 | Coco              |             7,200  |            7,810 |                     144  |                    156  |
-| **Yullo**            | /navi mjolnir_01 296/29       |            24 |            60 | Caramel           |            20,850  |           12,544 |                     417  |                    251  |
-| **Private Jeremy**   | /navi moc_fild11 57/138       |            25 |            60 | Golem             |            28,000  |           18,000 |                     560  |                    360  |
-| **Shone**            | /navi moc_fild17 208/346      |            25 |            60 | Hode              |            31,550  |           22,500 |                     631  |                    450  |
-| **Lemly**            | /navi moc_fild17 66/273       |            30 |            65 | Frilldora         |            60,000  |           46,000 |                   1,200  |                    900  |
-| **Li**               | /navi pay_fild10 108/357      |            35 |            70 | Dokebi            |            42,000  |           36,000 |                     840  |                    720  |
-| **Lella**            | /navi ayo_fild01 44/241       |            36 |            65 | Leaf Cat          |            25,740  |           31,512 |                     515  |                    630  |
-| **Cuir**             | /navi cmd_fild01 362/256      |            45 |            80 | Alligator         |           172,375  |          108,250 |                   3,448  |                  2,165  |
-| **Gandolf**          | /navi lhz_dun01 146/287       |            45 |            80 | Remover*          |           275,000  |          170,000 |                   5,500  |                  3,400  |
-| **Local Villager**    | /navi ein_fild01 43/249      |            60 |            74 | Demon Pungus      |           250,266  |          144,452 |                   5,005  |                  2,889  |
-| **Lilla**            | /navi um_fild01 35/281        |            60 |            85 | Dryad             |           234,855  |          126,905 |                   4,697  |                  2,538  |
-| **Shea**             | /navi tur_dun03 125/195       |            60 |            85 | Assaulter*        |           425,000  |          275,000 |                   8,500  |                  5,500  |
-| **Vegetable Farmer**  | /navi ein_fild06 82/171      |            70 |            95 | Goat              |           258,489  |          155,155 |                   5,170  |                  3,103  |
-| **Henry**            | /navi ice_dun03 140/26        |            70 |            95 | Ice Titan*        |           910,000  |          650,000 |                  18,200  |                 13,000  |
-| **Monica**           | /navi geffen 112/63           |            70 |            98 | Succubus*         |         1,325,000  |          950,000 |                  26,500  |                 19,000  |
-| **Miner**            | /navi beach_dun 269/71        |            75 |            97 | Medusa            |           515,700  |          352,275 |                  10,314  |                  7,046  |
-| **Jotun Tribesman**   | /navi mag_dun01 127/71       |            75 |            97 | Lava Golem        |           484,800  |          290,700 |                   9,696  |                  5,814  |
-| **Coal Miner**       | /navi mag_dun02 46/40         |            75 |            97 | Deleter           |           387,734  |          232,733 |                   7,755  |                  4,655  |
-| **Ptero**            | /navi abyss_03 117/31         |            75 |            97 | Gold Acidus*      |         1,285,000  |          815,000 |                  25,700  |                 16,300  |
-| **Kirby**            | /navi nyd_dun01 146/154       |            75 |            98 | Draco*            |           925,000  |          700,000 |                  18,500  |                 14,000  |
-| **Emmerich**         | /navi thor_v03 57/245         |            75 |            98 | Salamander*       |         2,150,000  |        1,550,000 |                  43,000  |                 31,000  |
+| NPC | Location | Min Level | Max Level | Monster | Base EXP | Job EXP | Base EXP / Monster | Job EXP / Monster |
+|:---|:---|---:|---:|:---|---:|---:|---:|---:|
+| **Langry** | `/navi gef_fild07 321/193` | 2 | 20 | Fabre | 770 | 60 | 15 | 1 |
+| **Halgus** | `/navi gef_fild04 191/54` | 2 | 20 | Pupa | 770 | 60 | 15 | 1 |
+| **Gregor** | `/navi moc_fild02 74/329` | 10 | 30 | Peco Peco | 8,000 | 4,000 | 160 | 80 |
+| **Laertes** | `/navi prt_fild04 356/148` | 15 | 45 | Creamy | 5,900 | 2,250 | 118 | 45 |
+| **Nutters** | `/navi mjolnir_01 293/20` | 18 | 60 | Coco | 7,200 | 7,810 | 144 | 156 |
+| **Yullo** | `/navi mjolnir_01 296/29` | 24 | 60 | Caramel | 20,850 | 12,544 | 417 | 251 |
+| **Private Jeremy** | `/navi moc_fild11 57/138` | 25 | 60 | Golem | 28,000 | 18,000 | 560 | 360 |
+| **Shone** | `/navi moc_fild17 208/346` | 25 | 60 | Hode | 31,550 | 22,500 | 631 | 450 |
+| **Lemly** | `/navi moc_fild17 66/273` | 30 | 65 | Frilldora | 60,000 | 46,000 | 1,200 | 900 |
+| **Li** | `/navi pay_fild10 108/357` | 35 | 70 | Dokebi | 42,000 | 36,000 | 840 | 720 |
+| **Lella** | `/navi ayo_fild01 44/241` | 36 | 65 | Leaf Cat | 25,740 | 31,512 | 515 | 630 |
+| **Cuir** | `/navi cmd_fild01 362/256` | 45 | 80 | Alligator | 172,375 | 108,250 | 3,448 | 2,165 |
+| **Gandolf** | `/navi lhz_dun01 146/287` | 45 | 80 | Remover* | 275,000 | 170,000 | 5,500 | 3,400 |
+| **Local Villager** | `/navi ein_fild01 43/249` | 60 | 74 | Demon Pungus | 250,266 | 144,452 | 5,005 | 2,889 |
+| **Lilla** | `/navi um_fild01 35/281` | 60 | 85 | Dryad | 234,855 | 126,905 | 4,697 | 2,538 |
+| **Shea** | `/navi tur_dun03 125/195` | 60 | 85 | Assaulter* | 425,000 | 275,000 | 8,500 | 5,500 |
+| **Vegetable Farmer** | `/navi ein_fild06 82/171` | 70 | 95 | Goat | 258,489 | 155,155 | 5,170 | 3,103 |
+| **Henry** | `/navi ice_dun03 140/26` | 70 | 95 | Ice Titan* | 910,000 | 650,000 | 18,200 | 13,000 |
+| **Monica** | `/navi geffen 112/63` | 70 | 98 | Succubus* | 1,325,000 | 950,000 | 26,500 | 19,000 |
+| **Miner** | `/navi beach_dun 269/71` | 75 | 97 | Medusa | 515,700 | 352,275 | 10,314 | 7,046 |
+| **Jotun Tribesman** | `/navi mag_dun01 127/71` | 75 | 97 | Lava Golem | 484,800 | 290,700 | 9,696 | 5,814 |
+| **Coal Miner** | `/navi mag_dun02 46/40` | 75 | 97 | Deleter | 387,734 | 232,733 | 7,755 | 4,655 |
+| **Ptero** | `/navi abyss_03 117/31` | 75 | 97 | Gold Acidus* | 1,285,000 | 815,000 | 25,700 | 16,300 |
+| **Kirby** | `/navi nyd_dun01 146/154` | 75 | 98 | Draco* | 925,000 | 700,000 | 18,500 | 14,000 |
+| **Emmerich** | `/navi thor_v03 57/245` | 75 | 98 | Salamander* | 2,150,000 | 1,550,000 | 43,000 | 31,000 |
 
 


### PR DESCRIPTION
Revises table data indicated from #36, fixes formatting, and revises content overall. 

Indicated that mercenary kills do count to monster hunting quests, though I'm not sure if homunculus does.